### PR TITLE
Document diving command

### DIFF
--- a/Messaging/Device Metadata.md
+++ b/Messaging/Device Metadata.md
@@ -267,12 +267,13 @@ Byte 4 is 0x1e
 # Diving
 ID: 0xDCC0004
 
-Handset sends diving status and dive number.
+Handset sends diving status, dive number and time of begin/end as 32 bits unix timestamp.
 
 | Byte          | Value           |
 | ------------- | -------------   |
 | 0             | Status          |
 | 1-2           | Dive Number     |
+| 3-8           | Timestamp       |
 
 
 | Byte 0 | Meaning         |

--- a/Messaging/Device Metadata.md
+++ b/Messaging/Device Metadata.md
@@ -263,3 +263,19 @@ Byte 4 is 0x1e
 | 1             | 0x23            |
 | 2-3           | 0x00            |
 | 4             | 0x1e            |
+
+# Diving
+ID: 0xDCC0004
+
+Handset sends diving status and dive number.
+
+| Byte          | Value           |
+| ------------- | -------------   |
+| 0             | Status          |
+| 1-2           | Dive Number     |
+
+
+| Byte 0 | Meaning         |
+| ------ | --------------- |
+| 0x00   | Begin           |
+| 0x01   | End             |

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Devices sharing an ID will behave identically with different controllers, this h
 | `0xC9`     | [Setpoint](Messaging/PPO2.md#setpoint)               |
 | `0xCA`     | [Cell status](Messaging/PPO2.md#cell-status)         |
 | `0xCB`     | [Status](Messaging/Device%20Metadata.md#status)      |
-| `0xCC`     | Unknown (sent by handset)                            |
+| `0xCC`     | [Diving](Messaging/Device%20Metadata.md#diving)      |
 | `0xD2`     | [Serial](Messaging/Device%20Metadata.md#serial)      |
 
 ## Testing


### PR DESCRIPTION
After more static analysis it seems 0xCC conveys diving status.
I guessed the ID. Really appreciate if you can check this against your logs.
Also im open for better name than "Diving" if you dont like like it.

