### PR TITLE
Shutdown rejected

### DIFF
--- a/Messaging/Device Metadata.md
+++ b/Messaging/Device Metadata.md
@@ -50,8 +50,21 @@ CAN: Fields: ACK delimiter: 0
 CAN: Fields: End of frame
 ```
 
-# Unknown metadata
-sent/received by handset, observed sent by SOLO, payload always 0x02, 0x01, 0x01 in recorded dataset.
+# Shutdown Reject
+A request to shutdown was rejected.
+
+| Byte          | Value           |
+| ------------- | --------------- |
+| 0             | HS sets to 0x00 |
+| 1-2           | Reason          |
+| 3-8           | HS sets to 0xff |
+
+| Reason | Meaning              |
+| ------ | -------------------- |
+| 0x21   | Unknown              |
+| 0x23   | Diving               |
+| 0x27   | FW updating          |
+| 0x28   | Bluetooth ON / Other |
 
 # Shutdown 
 ID: 0xD03000

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Devices sharing an ID will behave identically with different controllers, this h
 |------------|------------------------------------------------------|
 | `0x00`     | [Id](Messaging/Device%20Metadata.md#id)              |
 | `0x01`     | [Name](Messaging/Device%20Metadata.md#name)          |
-| `0x02`     | [Unknown metadata](Messaging/Device%20Metadata.md#Unknown-metadata)                                             |
+| `0x02`     | [Shutdown Rejected](Messaging/Device%20Metadata.md#shutdown-reject) |
 | `0x03`     | [Shutdown](Messaging/Device%20Metadata.md#shutdown)  | 
 | `0x04`     | [PPO2](Messaging/PPO2.md#ppo2)                       |
 | `0x07`     | [HUD Status](Messaging/Device%20Metadata.md#hud-status) |


### PR DESCRIPTION
This doesn't seem to match all to well with what have been observed earlier so i'm putting it as draft.

It seems like from the handset point of view 0x2 is only sent as a response to a 0x3 shutdown (and only in some cases).
So i assume it's a command/response thingie but it could also be a keep-alive.

There are a few "reasons" I have yet to figure out:
0x28 is sent if bluetooth is on. It is also be sent if bluetooth off, shutdown reason set to timeout and some handset internal value (to be determined) is smaller than 600. (surface interval? uptime?)
0x21: is another internal bool that can prevent shutdown.


Would really appreciate if some of this can be tested.
