### PR TITLE
Document Temp Probes

### DIFF
--- a/Messaging/Device Metadata.md
+++ b/Messaging/Device Metadata.md
@@ -206,17 +206,22 @@ CAN: Fields: ACK slot: ACK
 CAN: Fields: ACK delimiter: 1
 CAN: Fields: End of frame
 ```
-# Request Temp Probes Enabled
-ID: 0xDC1....
+
+# Temperature
+ID: 0DC10002
+
+Sent by scrubber with temperature sensor to handset. If handset has temp sensors disabled it will reply with [Temperature Probes enabled](#temperature-probes-enabled)
+
+| Byte  | Value   |
+| ------| ------- |
+| 0     | Sensor  |
+| 1-2   | Temperature |
+
+# Temperature Probes enabled
+ID: 0xDC40201
 
 
-Sent by Revo RB to query if handset has Temp Probes Enabled.
-
-# Temp Probes enabled
-ID: 0xDC4....
-
-
-Sent by handset when toggling temp probe enabled or as reply to [Request Temp Probes enabled](#request-temp-probes-enabled).
+Sent by handset when toggling temp probe enabled or as reply to [Temperature](#temperature).
 
 | Byte  | Value   |
 | ------| ------- |

--- a/Messaging/Device Metadata.md
+++ b/Messaging/Device Metadata.md
@@ -206,6 +206,27 @@ CAN: Fields: ACK slot: ACK
 CAN: Fields: ACK delimiter: 1
 CAN: Fields: End of frame
 ```
+# Request Temp Probes Enabled
+ID: 0xDC1....
+
+
+Sent by Revo RB to query if handset has Temp Probes Enabled.
+
+# Temp Probes enabled
+ID: 0xDC4....
+
+
+Sent by handset when toggling temp probe enabled or as reply to [Request Temp Probes enabled](#request-temp-probes-enabled).
+
+| Byte  | Value   |
+| ------| ------- |
+| 0     | Enabled |
+
+| Byte 0 | Value    |
+| -------| -------  |
+| 0x00   | Disabled |
+| 0x01   | Enabled  |
+
 
 # Serial Number
 ID: 0xDD20003

--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ Devices sharing an ID will behave identically with different controllers, this h
 | `0x23`     | [CO2 Calibration Init](Messaging/CO2.md#co2-calibration-request) |
 | `0x30`     | Unknown (sent by handset) (TODO, part of [menu system](Messaging/Bus%20Devices%20Menu.md)) |
 | `0x37`     | [BusInit](Messaging/Device%20Metadata.md#bus-init)   |
-| `0xC1`     | [Request Temp Probes enabled](Messaging/Device%20Metadata.md#request-temp-probes-enabled) |
+| `0xC1`     | [Temperature](Messaging/Device%20Metadata.md#temperature) |
 | `0xC3`     | Unknown (sent by handset)                            |
-| `0xC4`     | [Temp Probes enabled](Messaging/Device%20Metadata.md#temp-probes-enabled) |
+| `0xC4`     | [Temperature Probes enabled](Messaging/Device%20Metadata.md#temperature-probes-enabled) |
 | `0xC9`     | [Setpoint](Messaging/PPO2.md#setpoint)               |
 | `0xCA`     | [Cell status](Messaging/PPO2.md#cell-status)         |
 | `0xCB`     | [Status](Messaging/Device%20Metadata.md#status)      |

--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ Devices sharing an ID will behave identically with different controllers, this h
 | `0x23`     | [CO2 Calibration Init](Messaging/CO2.md#co2-calibration-request) |
 | `0x30`     | Unknown (sent by handset) (TODO, part of [menu system](Messaging/Bus%20Devices%20Menu.md)) |
 | `0x37`     | [BusInit](Messaging/Device%20Metadata.md#bus-init)   |
-| `0xC1`     | Unknown (recv by handset, sending results in 0xC4 back with 0x00 payload)                            |
+| `0xC1`     | [Request Temp Probes enabled](Messaging/Device%20Metadata.md#request-temp-probes-enabled) |
 | `0xC3`     | Unknown (sent by handset)                            |
-| `0xC4`     | Unknown (sent by handset)                            |
+| `0xC4`     | [Temp Probes enabled](Messaging/Device%20Metadata.md#temp-probes-enabled) |
 | `0xC9`     | [Setpoint](Messaging/PPO2.md#setpoint)               |
 | `0xCA`     | [Cell status](Messaging/PPO2.md#cell-status)         |
 | `0xCB`     | [Status](Messaging/Device%20Metadata.md#status)      |


### PR DESCRIPTION
0xC1 and 0xC4 are related to temp probes.

0xC1 sent by scrubber, updates temperatures list
0xC4 sent by handset telles if temperature reading is enabled. (can be observed when toggling the setting in rMS Settings (available with features: 48204)).

<img width="213" height="146" alt="image" src="https://github.com/user-attachments/assets/e10fe1be-f198-4398-af56-9bb3e7a288cf" />

https://www.revo-rebreathers.com/wp-content/uploads/2017/12/rMS-and-how-to-use-the-scrubber-monitoring-system-V-11.17.pdf

